### PR TITLE
Switch cake to build with DotNetBuild instead of MSBuild

### DIFF
--- a/recipe/build-settings.cake
+++ b/recipe/build-settings.cake
@@ -17,9 +17,6 @@ public static class BuildSettings
         string[] validConfigurations = null,
         string githubOwner = "NUnit",
 
-		bool msbuildAllowPreviewVersion = false,
-		Verbosity msbuildVerbosity = Verbosity.Minimal,
-
         string unitTests = null, // Defaults to "**/*.tests.dll|**/*.tests.exe" (case insensitive)
         IUnitTestRunner unitTestRunner = null, // If not set, NUnitLite is used
         string unitTestArguments = null,
@@ -189,14 +186,21 @@ public static class BuildSettings
 
     // Building
 	public static string[] ValidConfigurations { get; set; }
-	public static bool MSBuildAllowPreviewVersion { get; set; }
-	public static Verbosity MSBuildVerbosity { get; set; }
-	public static MSBuildSettings MSBuildSettings => new MSBuildSettings {
-		Verbosity = MSBuildVerbosity,
-		Configuration = Configuration,
-		PlatformTarget = PlatformTarget.MSIL,
-		AllowPreviewVersion = MSBuildAllowPreviewVersion
-	};
+    public static DotNetBuildSettings DotNetBuildSettings => new DotNetBuildSettings
+    {
+        Configuration = Configuration,
+        NoRestore = true,
+        Verbosity = DotNetVerbosity.Minimal,
+        MSBuildSettings = new DotNetMSBuildSettings
+        {
+            BinaryLogger = new MSBuildBinaryLoggerSettings
+            {
+                Enabled = true,
+                FileName = "build/NUnitConsole.binlog",
+                Imports = MSBuildBinaryLoggerImports.Embed
+            }
+        }.WithProperty("Version", BuildSettings.PackageVersion)
+    };
 
 	// File Header Checks
 	public static bool SuppressHeaderCheck { get; private set; }

--- a/recipe/task-definitions.cake
+++ b/recipe/task-definitions.cake
@@ -59,7 +59,8 @@ BuildTasks.RestoreTask = Task("Restore")
 		NuGetRestore(BuildSettings.SolutionFile, new NuGetRestoreSettings() {
 		    Source = new string[]	{ 
                 "https://www.nuget.org/api/v2",
-                "https://www.myget.org/F/nunit/api/v2" }
+                "https://www.myget.org/F/nunit/api/v2" },
+			Verbosity = NuGetVerbosity.Quiet
         });
 	});
 
@@ -71,7 +72,7 @@ BuildTasks.BuildTask = Task("Build")
 	.IsDependentOn("CheckHeaders")
 	.Description("Build the solution")
 	.Does(() =>	{
-		MSBuild(BuildSettings.SolutionFile, BuildSettings.MSBuildSettings.WithProperty("Version", BuildSettings.PackageVersion));
+		DotNetBuild(BuildSettings.SolutionFile, BuildSettings.DotNetBuildSettings);
 	});
 
 BuildTasks.UnitTestTask = Task("Test")


### PR DESCRIPTION
# Switch to using DotNetBuild action instead of MSBuild.
- NoRestore is specified because we have an explicit step to restore already, this should speed up builds a bit.
- Removed unused parameters from BuildSettings.Initialize (set defaults on BuildSettings directly, they can be overridden if necessary.
- Move .WithProperty("Version"...) inside BuildSettings property because it's recreating the settiings object on each call anyway, so it's unnecessary to have the caller do it.

# Enable binary logs
Binary logs contain more information and are significantly smaller than corresponding text logs.  This is especially helpful for CI builds where the reduced output makes it easier to figure out what's going on when looking at live logs, but still enables detailed debugging after the fact.
- Verbosity is set to Minimial for Build
- Verbosity is set to Quiet for Restore