### PR TITLE
Update binlog path.

### DIFF
--- a/recipe/build-settings.cake
+++ b/recipe/build-settings.cake
@@ -196,7 +196,7 @@ public static class BuildSettings
             BinaryLogger = new MSBuildBinaryLoggerSettings
             {
                 Enabled = true,
-                FileName = "build/NUnitConsole.binlog",
+                FileName = "build-results/NUnitConsole.binlog",
                 Imports = MSBuildBinaryLoggerImports.Embed
             }
         }.WithProperty("Version", BuildSettings.PackageVersion)


### PR DESCRIPTION
This fails to run because `build` exists an a bash script in the `nunit-console` root, so trying to create a file in `build\NUnitConsole.binlog` fails.  

I missed this in my testing because I made the change as an afterthought to try and avoid needing to modify the `.gitignore` file.  `build/` is ignored by default so I figured that'd be a good place to put it without even thinking to try it out. ☹️ 

I used `build-results` to parallel `test-results` which is currently used for all test output, but we can put it wherever.  I'll update the `.gitignore` with this folder.