### PR TITLE
Use alpha label for our myget builds; switch to semver 2.0

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -7,7 +7,7 @@ commits-since-version-source-padding: 5
 branches:
   master:
     regex: ^main$
-    tag: dev
+    tag: alpha
   release:
     tag: pre
   pull-request:

--- a/recipe/constants.cake
+++ b/recipe/constants.cake
@@ -47,7 +47,7 @@ private const string CHOCO_API_KEY = "CHOCO_API_KEY";
 private const string GITHUB_ACCESS_TOKEN = "GITHUB_ACCESS_TOKEN";
 
 // Pre-release labels that we publish
-private static readonly string[] LABELS_WE_PUBLISH_ON_MYGET = { "dev" };
-private static readonly string[] LABELS_WE_PUBLISH_ON_NUGET = { "alpha", "beta", "rc" };
-private static readonly string[] LABELS_WE_PUBLISH_ON_CHOCOLATEY = { "alpha", "beta", "rc" };
-private static readonly string[] LABELS_WE_RELEASE_ON_GITHUB = { "alpha", "beta", "rc" };
+private static readonly string[] LABELS_WE_PUBLISH_ON_MYGET = { "dev", "alpha" };
+private static readonly string[] LABELS_WE_PUBLISH_ON_NUGET = { "beta", "rc" };
+private static readonly string[] LABELS_WE_PUBLISH_ON_CHOCOLATEY = { "beta", "rc" };
+private static readonly string[] LABELS_WE_RELEASE_ON_GITHUB = { "beta", "rc" };

--- a/recipe/versioning.cake
+++ b/recipe/versioning.cake
@@ -86,13 +86,11 @@ public class BuildVersion
         if (label == branchName)
             label = "ci";
 
-        string suffix = "-" + label + _gitVersion.CommitsSinceVersionSourcePadded;
-
         switch (label)
         {
             case "ci":
                 branchName = Regex.Replace(branchName, "[^0-9A-Za-z-]+", "-");
-                suffix += "-" + branchName;
+                string suffix = $"-ci{_gitVersion.CommitsSinceVersionSourcePadded}-{branchName}";
                 // Nuget limits "special version part" to 20 chars. Add one for the hyphen.
                 if (suffix.Length > 21)
                     suffix = suffix.Substring(0, 21);
@@ -100,16 +98,12 @@ public class BuildVersion
 
             case "dev":
             case "pre":
-                return _gitVersion.MajorMinorPatch + suffix;
-
             case "pr":
-                return _gitVersion.LegacySemVerPadded;
-
             case "rc":
             case "alpha":
             case "beta":
             default:
-                return _gitVersion.LegacySemVer;
+                return _gitVersion.SemVer;
         }
     }
 }


### PR DESCRIPTION
Fixes #41

Since this impacts versioning for the engine, console runner and various extensions, I'd appreciate some reviews of the decisions I have made.

1. Alpha is used rather than dev for the myget automatic builds each time the main branch is built.
2. With one exception, all versions now use Semver 2.0 rather than 1.0. In GitVersion terms, that's SemVer rather than LegacySemVer.
3. The one exception is how ci builds are labeled. I'm very much open to suggestions for that.
