### PR TITLE
Add trigger to run workflow when release is published

### DIFF
--- a/.github/workflows/publish-recipe.yml
+++ b/.github/workflows/publish-recipe.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+  release:
+    types: [published]
 
 jobs:
   publish-recipe:


### PR DESCRIPTION
Fixes #54 

This will not be fully tested until we next publish a release on GitHub