### PR TITLE
Prepare for 1.4.0 release

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -15,7 +15,9 @@ jobs:
     - name: 🛠️ Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.100
+        dotnet-version: |
+          8.0.x
+          7.0.x
 
     - name: 🛠️ Install dotnet tools
       run: dotnet tool restore

--- a/.github/workflows/publish-recipe.yml
+++ b/.github/workflows/publish-recipe.yml
@@ -20,7 +20,9 @@ jobs:
     - name: 🛠️ Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.100
+        dotnet-version: |
+          8.0.x
+          7.0.x
 
     - name: 🛠️ Install dotnet tools
       run: dotnet tool restore

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ to create a single package.
 
 ```
 // Load the recipe
-#load nuget:?package=NUnit.Cake.Recipe&version=1.0.0 // Note 1
+#load nuget:?package=NUnit.Cake.Recipe&version=1.4.0 // Note 1
 
 // Initialize Build Settings
 BuildSettings.Initialize(                            // Note 2
@@ -34,11 +34,11 @@ Build.Run();                                         // Note 4
 **NOTES:**
 
 1. The `#load` statement loads `NUnit.Cake.Recipe`, specifying the version to use, 
-   in this case version 1.0.0. It is recommended that you specify the recipe 
+   in this case version 1.4.0. You should always specify the recipe 
    version to avoid unpleasant surprises when the recipe is updated.
 
 2. `BuildSettings.Initialize` sets the parameters which drive the build process. The example
-   specifies only the three required paraameters.
+   specifies only the three required arguments.
 
 3. Define a single `nuget` package.
 
@@ -49,19 +49,15 @@ Build.Run();                                         // Note 4
 The recipe supports a number of standard command-line arguments. Additional arguments may be
 supported directly by the user's `build.cake` file, but must not conflict with the built-in arguments.
 
-Arguments taking a value may use  `=` or space to separate the name from the value and
-may be specified in abbreviated form, down to the minimum length shown in square braces.
-Single character abbreviations use a single dash.
-
-#### --target=TARGET              [-t]
+#### --target, -t=TARGET
 The name of the TARGET task to be run, e.g. Test. Default is "Build." For a list
 of supported targets, use the Cake `--description` option.
 
-#### --configuration=CONFIG       [-c]
+#### --configuration, -c=CONFIG
 The name of the configuration to build, test and/or package, e.g. Debug.
 Defaults to Release.
 
-#### --packageVersion=VERSION     [--pack]
+#### --packageVersion=VERSION
 Specifies the full package version, including any pre-release
 suffix. This version is used directly instead of the default
 version from the script or that calculated by GitVersion.
@@ -70,17 +66,16 @@ derived from the package version.
 
 NOTE: We can't use "version" since that's an argument to Cake itself.
 
-#### --where=SELECTION            [-w]
-Specifies a selction expression used to choose which packages
-to build and test, for use in debugging. Consists of one or
-more specifications, separated by '|' and '&'. Each specification
-is of the form "prop=value", where prop may be either id or type.
-Examples:
-* --where type=nuget
-* --where id=NUnit.Engine.Api
-* --where "type=nuget|type=choco"
+#### --packageId, --id=ID
+Specifies the id of a package for which packaging is to be performed.
+If not specified, all ids are processed.
 
-#### --level=LEVEL                [--lev]
+#### --packageType, --type=TYPE
+Specifies the type package for which packaging is to be performed.
+Valid values for TYPE are 'nuget', 'choco' and 'zip'.
+If not specified, all types are processed.
+
+#### --level, --lev=LEVEL
 Specifies the level of package testing, which is normally set
 automatically for different types of builds like CI, PR, etc.
 Used by developers to test packages locally without creating
@@ -89,17 +84,17 @@ a PR or publishing the package. Defined levels are
   2. Adds more tests for PRs and Dev builds uploaded to MyGet
   3. Adds even more tests prior to publishing a release
 
-#### --trace=LEVEL                [--tr]
+#### --trace, --tr=LEVEL
 Specifies the default trace level for this run. Values are Off,
 Error, Warning, Info or Debug. Default is Off.
 
-#### --nobuild                    [--nob]
+#### --nobuild, --nob
 Indicates that the Build task should not be run even if other
 tasks depend on it. The existing build is used instead.
 
-#### --nopush                     [--nop]
+#### --nopush, --nop
 Indicates that no publishing or releasing should be done. If
 publish or release targets are run, a message is displayed.
 
-#### --usage                 [--us]
+#### --usage
 Displays a general help message. No targets are run.


### PR DESCRIPTION
Update Readme and workflows in preparation for the release.

Note: the version of GitReleaseManager we are using requires .NET 7.0.